### PR TITLE
fix(theme): resolve invisible button text in reading mode

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -383,7 +383,7 @@ const GuestHomePage = () => {
           </div>
           <div className="flex items-center space-x-4">
             <ThemeToggle />
-            <Button asChild variant="default" className="bg-gradient-primary hover:shadow-glow">
+            <Button asChild variant="default" className="bg-gradient-primary hover:shadow-glow ">
               <Link to="/login">Get Started</Link>
             </Button>
           </div>
@@ -435,7 +435,7 @@ const GuestHomePage = () => {
             <Button
               asChild
               size="xl"
-              className="text-lg bg-gradient-primary hover:shadow-glow btn-enhanced"
+              className="text-lg bg-gradient-primary hover:shadow-glow btn-enhanced "
             >
               <Link to="/login">
                 Get Started Free
@@ -742,7 +742,7 @@ const GuestHomePage = () => {
                     size="xl"
                     className="text-lg text-white align-middle px-8 py-4 rounded-full shadow-md"
                   >
-                    <Link to="/login" aria-label="Get started - free">
+                    <Link to="/login" className='bg-gradient-primary' aria-label="Get started - free">
                       Get Started — It's Free
                     </Link>
                   </Button>

--- a/src/styles/enhanced-theme.css
+++ b/src/styles/enhanced-theme.css
@@ -194,11 +194,16 @@
 }
 
 /* Reading Mode Link Styling */
-.reading-mode a {
+.reading-mode a:not([class*="bg-gradient-primary"]) {
   color: hsl(var(--primary)) !important;
   text-decoration: underline !important;
   text-decoration-thickness: 2px !important;
   text-underline-offset: 2px !important;
+}
+
+.reading-mode .bg-gradient-primary a {
+  color: hsl(var(--primary-foreground)) !important;
+  text-decoration: none !important;
 }
 
 .reading-mode a:hover {
@@ -310,6 +315,8 @@
   animation: reading-mode-enter 0.3s ease-out;
 }
 
+
+
 /* Responsive Reading Mode */
 @media (max-width: 768px) {
   .reading-mode .prose,
@@ -342,3 +349,4 @@
     border: none !important;
   }
 }
+


### PR DESCRIPTION
## 📝 Description

This pull request fixes a critical UI bug where the text inside the primary "Get Started" buttons on the homepage becomes invisible when "Reading Mode" is activated.

The root cause was an overly broad CSS rule in enhanced-theme.css that forced all link (<a>) colors to match the primary blue, which is also the button's background color. This change introduces a more specific CSS override that targets only the links inside primary buttons and forces their text color to the correct high-contrast variable (--primary-foreground), ensuring they are always visible in Reading Mode.

## 🔗 Related Issue

Closes #27 

## 🔧 Type of Change

Please select the type of change you are making:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify)

I have manually tested this by:

Navigating to the homepage.

Toggling "Reading Mode" ON and OFF.

Verifying the "Get Started" button text remains white and clearly visible in Reading Mode.

Verifying the button text is also correct in both standard light and dark modes.

Verifying that other text links on the page are not affected and still display correctly in Reading Mode.

## 📷 Screenshots
Before : 
<img width="1896" height="937" alt="image" src="https://github.com/user-attachments/assets/5f39e6c4-7db2-4fd6-b5d6-2a5bdfee90db" />
After:
<img width="1900" height="940" alt="image" src="https://github.com/user-attachments/assets/946d479a-8b08-4c54-b5a6-149a8fa4e22c" />
