### PR TITLE
fix: Make Mood Trend chart in analytics dynamic

### DIFF
--- a/src/components/dashboard/InteractiveAnalytics.tsx
+++ b/src/components/dashboard/InteractiveAnalytics.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react'; // --- 1. IMPORT useMemo ---
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import {
@@ -47,6 +47,24 @@ export const InteractiveAnalytics = () => {
   const moodTrend = getMoodTrend();
   const goalProgress = getWeeklyGoalProgress();
   const averageSleep = getAverageHours();
+
+  // --- 2. ADD THIS DYNAMIC FILTERING LOGIC ---
+  const filteredMoods = useMemo(() => {
+    const now = Date.now();
+    const daysToFilter = {
+      week: 7,
+      month: 30,
+      '3months': 90,
+    }[selectedTimeframe];
+
+    const cutoffDate = now - daysToFilter * 24 * 60 * 60 * 1000;
+    
+    // Filter moods and then take the most recent ones matching the timeframe
+    return moods
+      .filter((mood) => mood.timestamp >= cutoffDate)
+      .slice(-daysToFilter); // Ensure we don't show more bars than the timeframe allows
+  }, [moods, selectedTimeframe]);
+  // --- END OF ADDED LOGIC ---
 
   const getMetricTrend = (current: number, previous: number) => {
     if (current > previous + 0.1) return { trend: 'up', icon: ArrowUp, color: 'text-green-500' };
@@ -195,13 +213,15 @@ export const InteractiveAnalytics = () => {
                     <div className="p-4 border rounded-lg">
                       <h4 className="font-semibold mb-3 flex items-center">
                         <Heart className="h-4 w-4 mr-2 text-red-500" />
-                        Mood Trend ({selectedTimeframe})
+                        Mood Trend ({selectedTimeframe === '3months' ? '3 Months' : `This ${selectedTimeframe}`})
                       </h4>
                       <div className="flex items-end space-x-2 h-24">
-                        {moods.slice(-7).map((mood, index) => (
+                        {/* --- 3. USE THE DYNAMICALLY FILTERED DATA --- */}
+                        {filteredMoods.map((mood, index) => (
                           <div key={index} className="flex flex-col items-center flex-1">
                             <div
-                              className="bg-gradient-to-t from-primary to-secondary rounded-t opacity-70"
+                              title={`Mood: ${mood.mood}/5 on ${new Date(mood.date).toLocaleDateString()}`}
+                              className="w-full bg-gradient-to-t from-primary to-secondary rounded-t opacity-70 hover:opacity-100 transition-opacity"
                               style={{ height: `${(mood.mood / 5) * 100}%`, minHeight: '4px' }}
                             />
                             <span className="text-xs text-muted-foreground mt-1">


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug in the `InteractiveAnalytics` component where the "Mood Trend" chart in the details dialog was not updating based on the selected timeframe.

The chart is now fully dynamic and correctly filters mood data for "This Week", "This Month", and "3 Months", providing an accurate and interactive user experience.

**Changes:**
- Imported `useMemo` in `InteractiveAnalytics.tsx`.
- Added logic to create a `filteredMoods` array that dynamically filters mood entries based on the selected timeframe.
- Updated the chart's `.map()` function to use the new `filteredMoods` array.
- Added a `title` attribute to the chart bars for better accessibility and user experience (shows mood score on hover).

## 🔗 Related Issue

Closes #87

## 🔧 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify)

## ✅ Checklist

- [x] I have read the [contribution guidelines](CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] Code follows project conventions
- [x] No console errors
- [ ] Documentation updated if needed