### PR TITLE
Fix: Resolve multiple frontend bugs and linter warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,9 +49,8 @@
     <!-- Accessibility -->
     <meta name="color-scheme" content="light dark" />
 
-    <!-- Security -->
+    <!-- Security (set HTTP security headers at the server; meta X-Frame-Options is invalid) -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
-    <meta http-equiv="X-Frame-Options" content="DENY" />
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="/logo.png" />
     <link rel="apple-touch-icon" href="/logo.png" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import Layout from '@/components/layout/Layout';
 import ChatWidget from '@/components/chat/ChatWidget';
 import NotificationContainer from '@/components/notifications/NotificationContainer';
 import { lazy, Suspense, useEffect } from 'react';
+import { ErrorBoundary, PageErrorBoundary } from '@/components/error';
 import ScrollToTop from './components/layout/scrollToTop';
 
 // Lazy load pages for better performance

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -37,7 +37,6 @@ import { useState, useEffect, useRef } from 'react';
  * @see {@link ../../types/notifications} For notification integration
  */
 
-import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   MessageCircle,


### PR DESCRIPTION
This commit addresses several issues found during setup: Fixed duplicate React hook import in src/components/chat/ChatWidget.tsx that caused “Identifier 'useState' has already been declared.”

Removed invalid <meta http-equiv="X-Frame-Options"> from index.html (must be set via HTTP header; use CSP frame-ancestors server-side).

Imported ErrorBoundary and PageErrorBoundary in src/App.tsx to resolve “ErrorBoundary is not defined.”

## 📝 Description

Fixes to multiple setup and linting errors for local environment initialization. This PR addresses several issues found during initial setup: 1. Fixed duplicate React hook import in src/components/chat/ChatWidget.tsx that caused 'useState' to be declared twice. 2.  Removed invalid <meta http-equiv="X-Frame-Options"> from index.html (header security should be handled server-side). 3. Imported ErrorBoundary and PageErrorBoundary in src/App.tsx to resolve "ErrorBoundary is not defined" error.

## 🔗 Related Issue

Closes Issues #116 

## 🔧 Type of Change

Please select the type of change you are making:

- [ x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify)

## ✅ Checklist

- [x ] I have read the [contribution guidelines](CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x ] Code follows project conventions
- [x ] No console errors
- [ ] Documentation updated if needed

## 📷 Screenshots
N/A

## Additional Notes

These initial fixes should resolve basic errors for new contributors attempting to spin up the local development environment