### PR TITLE
Fix/login autofill bug

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { toast } from 'react-toastify';
 import { useNavigate, Link } from 'react-router-dom';
 import { Button } from '@/components/ui/button';


### PR DESCRIPTION
## 📝 Description

Removed the default auto-fill of demo credentials (admin@mindbuddy.com / admin123) from the login page.
Previously, credentials were being populated automatically on page load due to the handleRoleChange function.
Now, the email and password fields remain empty by default, unless demo mode is explicitly enabled (e.g. in development).

## 🔗 Related Issue

Fixes #127

## 🔧 Type of Change

Please select the type of change you are making:

- [ ✅] Bug fix