### PR TITLE
Updates the role in the credentials state and preserves whatever the user types its credentials

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -63,18 +63,13 @@ const Login = () => {
   };
 
   const handleRoleChange = (role: 'student' | 'counselor' | 'admin') => {
-    // Auto-fill credentials for demo
-    const demoCredentials = {
-      student: { email: 'student@mindbuddy.com', password: 'student123' },
-      counselor: { email: 'counselor@mindbuddy.com', password: 'counselor123' },
-      admin: { email: 'admin@mindbuddy.com', password: 'admin123' },
-    };
 
-    setCredentials({
-      ...demoCredentials[role],
-      role,
-    });
-  };
+    const handleRoleChange = (role: 'student' | 'counselor' | 'admin') => {
+      setCredentials((prev) => ({
+        ...prev,
+        role,
+      }));
+    };
 
   const getRoleIcon = (role: string) => {
     switch (role) {


### PR DESCRIPTION
Description
Prevented demo credentials from auto-filling when switching roles on the login page. Updated handleRoleChange in src/pages/Login.tsx to only update the role in credentials and preserve whatever the user has already typed in the email/password fields. The “Demo Credentials” section remains visible for reference but no longer alters the inputs automatically.

🔗 Related Issue
Fixes #127

🔧 Type of Change
[x] Bug fix

📷 Screenshots
<img width="1881" height="902" alt="Screenshot 2025-10-10 202730" src="https://github.com/user-attachments/assets/b81081bc-d8f7-4183-a7d1-6da2213557c6" />
<img width="1873" height="898" alt="Screenshot 2025-10-10 202722" src="https://github.com/user-attachments/assets/740c472a-36a2-4d3d-bec7-9bbb591019b5" />

Additional Notes
Changed handleRoleChange to: only setCredentials((prev) => ({ ...prev, role })).
Keeps user-entered email and password intact when toggling between Student/Counselor/Admin.
Demo credentials remain visible in the UI for manual copy-paste.